### PR TITLE
Add new customNANPackageName option, fix locateNAN, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Configuration is done entirely via `package.json`, you can specify multiple buil
   "targetDirectory": "build", // where to build your project
   "buildType": "Release", // Debug or Release build, most likely set it to Release
   "projectName": "addon" // The name of your CMake project.
+  "globalCMakeOptions": [{ //*Optionally*, you can specify global CMAKE flags here!
+      "name": "CMAKE_EXPORT_COMPILE_COMMANDS",
+      "value": "1"
+  }],
+  "customNANPackageName": "@myawesomenamespace/nan" //*Optionally*, you can specify a custom nan (native node abstractions) package name here
 }
 ```
 

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -60,7 +60,10 @@ export class ArgumentBuilder {
     }
 
     // Search NAN if installed and required
-    const nan = await locateNAN(this.options.packageDirectory);
+    const nan = await locateNAN(this.options.packageDirectory, this.options.customNANPackageName);
+    if(!!this.options.customNANPackageName && !nan) {
+      console.log('WARNING: customNANPackageName was specified, but module "' + this.options.customNANPackageName + '" could not be found!');
+    }
     if (nan) {
       includes.push(nan);
     }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -28,6 +28,8 @@ export type BuildOptions = {
   buildType: string,
   // global cmake options and defines
   globalCMakeOptions?: { name: string, value: string }[];
+  // custom native node abstractions package name if you use a fork instead of official nan
+  customNANPackageName?: string;
 }
 
 export class CMakeWrapper {

--- a/src/locateNAN.ts
+++ b/src/locateNAN.ts
@@ -1,14 +1,17 @@
 import { STAT } from './util';
 import { join as joinPath, sep as pathSeparator, normalize as normalizePath } from 'path';
 
-export const locateNAN = async (projectRoot: string): Promise<string | null> => {
+export const locateNAN = async (projectRoot: string, customNANPackageName?: string): Promise<string | null> => {
   const isNode = await isNodeProject(projectRoot);
   if (!isNode) {
     return null;
   }
-  const nanPath = joinPath(projectRoot, 'node_modules', 'nan');
-  const isNan = isNANModule(nanPath);
+  const nanPath = joinPath(projectRoot, 'node_modules', customNANPackageName || 'nan');
+  const isNan = await isNANModule(nanPath);
   if (isNan) {
+    if(!!customNANPackageName) {
+      console.log('Located custom nan package "' + customNANPackageName + '" at path ' + nanPath + '!');
+    }
     return nanPath;
   }
   return locateNAN(goUp(projectRoot));


### PR DESCRIPTION
This PR adds a new option `customNANPackageName`.
This option enables the user to specify a custom package name for the Native Node Abstractions in case they use a fork.

Additionally, the `locateNAN` function was fixed. It always emitted `true`, because of the following line: `const isNan = isNANModule(nanPath);`. `isNANModule` is an async, therefore an await must be added:
`const isNan = await isNANModule(nanPath);`, because otherwise, the returned promise is checked for its validity and not, as intended, the value of the promise put into `isNan`.

Furthermore, the new option was documented in the the `README.MD` file, together with the previously undocumented option `"globalCMakeOptions"`