### PR TITLE
Multiple enhancements from real world experiences (v1.x?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Configuration is done entirely via `package.json`. You can specify multiple buil
 
 ```js
 "cmake-ts": {
-  "nodeAPI": "node-addon-api" // Specify the node API package such as `node-addon-api`, `nan`, or the path to a directory that has the nodeAPI header. By default `nan` is considered.
+  "nodeAPI": "node-addon-api" // Specify the node API package such as `node-addon-api`, `nan`, or the path to a directory that has the nodeAPI header. Default is `node-addon-api`, a warning is emitted if nan is used
   "configurations": [
     {
       "os": "win32", // win32, linux and darwin are supported

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Configuration is done entirely via `package.json`. You can specify multiple buil
   "nodeAPI": "node-addon-api" // Specify the node API package such as `node-addon-api`, `nan`, or the path to a directory that has the nodeAPI header. Default is `node-addon-api`, a warning is emitted if nan is used
   "configurations": [
     {
+      "name": "win-x64", // name for named-configs mode
       "os": "win32", // win32, linux and darwin are supported
       "arch": "x64", // x64, x86 should work
       "runtime": "electron", // node or electron
@@ -25,9 +26,11 @@ Configuration is done entirely via `package.json`. You can specify multiple buil
           "name": "MY_CMAKE_OPTION",
           "value": "my_value",
         }
-      ]
+      ],
+      "addonSubdirectory": "avx2-generic" // if you build addons for multiple architectures in high performance scenarios, you can put the addon inside another subdirectory
     }, // more build configurations...
     {
+      "dev": true, // whether this configuration is eligible to be used in a dev test build
       "os": "linux", // win32, linux and darwin are supported
       "arch": "x64", // x64, x86 should work
       "runtime": "node", // node or electron
@@ -52,15 +55,18 @@ Configuration is done entirely via `package.json`. You can specify multiple buil
 
 ## Workflow
 
-While it is desirable to perform a full build (all configurations) within a CI environment, long build times hinder local package development. Therefore cmake-ts knows not only the `build` target but also two other targets:
+While it is desirable to perform a full build (all configurations) within a CI environment, long build times hinder local package development. Therefore cmake-ts knows multiple build modes:
 
-- `nativeonly` -> Builds the native code **only** for the runtime cmake-ts is currently running on, ignoring all previously specified configurations. This is useful if you'd like to run some unit tests against the compiled code. When running `cmake-ts nativeonly`, cmake-ts will determine the runtime, ABI, and platform from the environment, and build only the configuration required to run on this platform.
+- **TODO** `nativeonly` -> Builds the native code **only** for the runtime cmake-ts is currently running on, ignoring all previously specified configurations. This is useful if you'd like to run some unit tests against the compiled code. When running `cmake-ts nativeonly`, cmake-ts will determine the runtime, ABI, and platform from the environment, and build only the configuration required to run on this platform.
   - *Example using the configuration above*
   - You run `cmake-ts nativeonly` on **NodeJS 11.7 on MacOS**, `cmake-ts` will **ignore** all specified configurations above and build the native addon for **NodeJS 11.7 on MacOS**
-- `osonly` -> Builds the native code for all configurations which match the current operating system. This is useful for those developing for example an electron addon and want to test their code in electron. In such a case, you would specify electron and NodeJS runtimes for several platforms in your configuration and you can use `cmake-ts osonly` to build a local package you can install in your application.
+- **TODO** `osonly` -> Builds the native code for all configurations which match the current operating system. This is useful for those developing for example an electron addon and want to test their code in electron. In such a case, you would specify electron and NodeJS runtimes for several platforms in your configuration and you can use `cmake-ts osonly` to build a local package you can install in your application.
   - *Example using the configuration above*
   - You run `cmake-ts osonly` on **NodeJS 11.7 on Linux**, `cmake-ts` will **ignore** all configurations above where `os != linux` and build the native addon for **all** remaining configurations, in this case it will build for **NodeJS 10.3 on Linux**.
-- **HINT**: For both `osonly` and `nativeonly`, the specified CMake Toolchain files are ignored since I assume you got your toolchain set up correctly for your **own** operating system.
+- **TODO** **HINT**: For both `osonly` and `nativeonly`, the specified CMake Toolchain files are ignored since I assume you got your toolchain set up correctly for your **own** operating system.
+- None / Omitted: Builds all configs
+- `dev-os-only` builds the first config that has `dev == true` and `os` matches the current OS
+- `named-configs arg1 arg2 ...` builds all configs for which `name` is one of the args
 
 ## Cross Compilation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ Configuration is done entirely via `package.json`. You can specify multiple buil
       "arch": "x64", // x64, x86 should work
       "runtime": "electron", // node or electron
       "runtimeVersion": "4.0.1", // Version of the runtime which it is built
-      "toolchainFile": "/windows.cmake" // CMake Toolchain file to use for crosscompiling
+      "toolchainFile": "/windows.cmake" // CMake Toolchain file to use for crosscompiling,
+      "CMakeOptions": [ //Same syntax as for the globalCMakeOptions
+        {
+          "name": "MY_CMAKE_OPTION",
+          "value": "my_value",
+        }
+      ]
     }, // more build configurations...
     {
       "os": "linux", // win32, linux and darwin are supported

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Configuration is done entirely via `package.json`. You can specify multiple buil
       "arch": "x64", // x64, x86 should work
       "runtime": "electron", // node or electron
       "runtimeVersion": "4.0.1", // Version of the runtime which it is built
-      "toolchainFile": "/windows.cmake" // CMake Toolchain file to use for crosscompiling,
+      "toolchainFile": "/windows.cmake", // CMake Toolchain file to use for crosscompiling
       "CMakeOptions": [ //Same syntax as for the globalCMakeOptions
         {
           "name": "MY_CMAKE_OPTION",

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -64,11 +64,14 @@ export class ArgumentBuilder {
     }
 
     // Search nodeAPI if installed and required
-    if(this.options.nodeAPI?.includes('nan')) {
-      console.log(`WARNING: specified nodeAPI ${this.options.nodeAPI} seems to be nan - The usage of nan is discouraged due to subtle and hard-to-fix ABI issues! Consider using node-addon-api / N-API instead!`)
+    if (this.options.nodeAPI?.includes('nan')) {
+      console.warn(`WARNING: specified nodeAPI ${this.options.nodeAPI} seems to be nan - The usage of nan is discouraged due to subtle and hard-to-fix ABI issues! Consider using node-addon-api / N-API instead!`)
+    }
+    if (!this.options.nodeAPI) {
+      console.warn('WARNING: nodeAPI was not specified. The default changed from "nan" to "node-addon-api" in v0.3.0! Please make sure this is intended.');
     }
     const nodeApiInclude = await getNodeApiInclude(this.options.packageDirectory, this.options.nodeAPI ?? "node-addon-api");
-    if(Boolean(this.options.nodeAPI) && !nodeApiInclude) {
+    if (this.options.nodeAPI && !nodeApiInclude) {
       console.log(`WARNING: nodeAPI was specified, but module "${this.options.nodeAPI}" could not be found!`);
     }
     if (nodeApiInclude) {

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -64,7 +64,10 @@ export class ArgumentBuilder {
     }
 
     // Search nodeAPI if installed and required
-    const nodeApiInclude = await getNodeApiInclude(this.options.packageDirectory, this.options.nodeAPI ?? "nan");
+    if(this.options.nodeAPI?.includes('nan')) {
+      console.log(`WARNING: specified nodeAPI ${this.options.nodeAPI} seems to be nan - The usage of nan is discouraged due to subtle and hard-to-fix ABI issues! Consider using node-addon-api / N-API instead!`)
+    }
+    const nodeApiInclude = await getNodeApiInclude(this.options.packageDirectory, this.options.nodeAPI ?? "node-addon-api");
     if(Boolean(this.options.nodeAPI) && !nodeApiInclude) {
       console.log(`WARNING: nodeAPI was specified, but module "${this.options.nodeAPI}" could not be found!`);
     }

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -93,8 +93,8 @@ export class ArgumentBuilder {
         retVal.push([j.name, j.value.replace(/\$ROOT\$/g, resolve(this.options.packageDirectory))]);
       });
     }
-    if (this.config.cmakeOptions && this.config.cmakeOptions.length > 0) {
-      this.config.cmakeOptions.forEach(j => {
+    if (this.config.CMakeOptions && this.config.CMakeOptions.length > 0) {
+      this.config.CMakeOptions.forEach(j => {
         retVal.push([j.name, j.value.replace(/\$ROOT\$/g, resolve(this.options.packageDirectory))]);
       });
     }

--- a/src/buildMode.ts
+++ b/src/buildMode.ts
@@ -34,6 +34,6 @@ export async function determineBuildMode(argv: string[]): Promise<BuildMode> {
     }
 
     //Yeah whatever, we don't have any proper error handling anyway at the moment
-    console.error(`Unknown command line option ${argv[0]} - Valid are 'nativeonly', 'osonly' and omitted`);
+    console.error(`Unknown command line option ${argv[0]} - Valid are none/omitted, 'nativeonly', 'osonly', 'dev-os-only' and 'named-configs'`);
     process.exit(1);
 }

--- a/src/buildMode.ts
+++ b/src/buildMode.ts
@@ -4,6 +4,8 @@ export type BuildMode = {
     'type': 'nativeonly'
   } | {
     'type': 'all'
+  } | {
+    'type': 'dev-os-only'
   }
 
 export async function determineBuildMode(argv: string[]): Promise<BuildMode> {
@@ -14,6 +16,8 @@ export async function determineBuildMode(argv: string[]): Promise<BuildMode> {
     if(argv[0] === 'nativeonly') return {'type': 'nativeonly'}
 
     if(argv[0] === 'osonly') return {'type': 'osonly'}
+
+    if(argv[0] === 'dev-os-only') return {'type': 'dev-os-only'}
 
     //Yeah whatever, we don't have any proper error handling anyway at the moment
     console.error(`Unknown command line option ${argv[0]} - Valid are 'nativeonly', 'osonly' and omitted`);

--- a/src/buildMode.ts
+++ b/src/buildMode.ts
@@ -1,0 +1,21 @@
+export type BuildMode = {
+    'type': 'osonly'
+  } | {
+    'type': 'nativeonly'
+  } | {
+    'type': 'all'
+  }
+
+export async function determineBuildMode(argv: string[]): Promise<BuildMode> {
+
+    //If no arguments are specified, build all setups
+    if(argv.length === 0) return {'type': 'all'}
+
+    if(argv[0] === 'nativeonly') return {'type': 'nativeonly'}
+
+    if(argv[0] === 'osonly') return {'type': 'osonly'}
+
+    //Yeah whatever, we don't have any proper error handling anyway at the moment
+    console.error(`Unknown command line option ${argv[0]} - Valid are 'nativeonly', 'osonly' and omitted`);
+    process.exit(1);
+}

--- a/src/buildMode.ts
+++ b/src/buildMode.ts
@@ -11,29 +11,37 @@ export type BuildMode = {
     configsToBuild: string[]
   }
 
-export async function determineBuildMode(argv: string[]): Promise<BuildMode> {
+export function determineBuildMode(argv: string[]): BuildMode {
 
-    //If no arguments are specified, build all setups
-    if(argv.length === 0) return {type: 'all'}
+    // If no arguments are specified, build all setups
+    if (argv.length === 0) {
+      return { type: 'all' };
+    }
 
-    if(argv[0] === 'nativeonly') return {type: 'nativeonly'}
+    if (argv[0] === 'nativeonly') {
+      return { type: 'nativeonly' };
+    }
 
-    if(argv[0] === 'osonly') return {type: 'osonly'}
+    if (argv[0] === 'osonly') {
+      return { type: 'osonly' };
+    }
 
-    if(argv[0] === 'dev-os-only') return {type: 'dev-os-only'}
+    if (argv[0] === 'dev-os-only') {
+      return { type: 'dev-os-only' };
+    }
 
-    if(argv[0] === 'named-configs') {
-      if(argv.length < 2) {
+    if (argv[0] === 'named-configs') {
+      if (argv.length < 2) {
         console.error(`'named-configs' needs at least one config name`);
         process.exit(1);
       }
       return {
         type: 'named-configs',
-        configsToBuild: argv.slice(1)
-      }
+        configsToBuild: argv.slice(1),
+      };
     }
 
-    //Yeah whatever, we don't have any proper error handling anyway at the moment
+    // Yeah whatever, we don't have any proper error handling anyway at the moment
     console.error(`Unknown command line option ${argv[0]} - Valid are none/omitted, 'nativeonly', 'osonly', 'dev-os-only' and 'named-configs'`);
     process.exit(1);
 }

--- a/src/buildMode.ts
+++ b/src/buildMode.ts
@@ -1,23 +1,37 @@
 export type BuildMode = {
-    'type': 'osonly'
+    type: 'osonly'
   } | {
-    'type': 'nativeonly'
+    type: 'nativeonly'
   } | {
-    'type': 'all'
+    type: 'all'
   } | {
-    'type': 'dev-os-only'
+    type: 'dev-os-only'
+  } | {
+    type: 'named-configs',
+    configsToBuild: string[]
   }
 
 export async function determineBuildMode(argv: string[]): Promise<BuildMode> {
 
     //If no arguments are specified, build all setups
-    if(argv.length === 0) return {'type': 'all'}
+    if(argv.length === 0) return {type: 'all'}
 
-    if(argv[0] === 'nativeonly') return {'type': 'nativeonly'}
+    if(argv[0] === 'nativeonly') return {type: 'nativeonly'}
 
-    if(argv[0] === 'osonly') return {'type': 'osonly'}
+    if(argv[0] === 'osonly') return {type: 'osonly'}
 
-    if(argv[0] === 'dev-os-only') return {'type': 'dev-os-only'}
+    if(argv[0] === 'dev-os-only') return {type: 'dev-os-only'}
+
+    if(argv[0] === 'named-configs') {
+      if(argv.length < 2) {
+        console.error(`'named-configs' needs at least one config name`);
+        process.exit(1);
+      }
+      return {
+        type: 'named-configs',
+        configsToBuild: argv.slice(1)
+      }
+    }
 
     //Yeah whatever, we don't have any proper error handling anyway at the moment
     console.error(`Unknown command line option ${argv[0]} - Valid are 'nativeonly', 'osonly' and omitted`);

--- a/src/download.ts
+++ b/src/download.ts
@@ -56,10 +56,8 @@ export async function downloadToString(url: string): Promise<string> {
   return result.toString()
 }
 
-export async function downloadFile(url: string, options: string | DownloadOptions): Promise<string| null> {
-  if (isString(options)) {
-    options = { path: options };
-  }
+export async function downloadFile(url: string, opts: string | DownloadOptions): Promise<string| null> {
+  const options = isString(opts) ? { path: opts } : opts;
 
   const result = createWriteStream(options.path as string);
   const sum = await downloadToStream(url, result, options.hashType);
@@ -69,10 +67,9 @@ export async function downloadFile(url: string, options: string | DownloadOption
   return sum;
 }
 
-export async function downloadTgz(url: string, options: string | DownloadOptions): Promise<string | null> {
-  if (isString(options)) {
-    options = { cwd: options };
-  }
+export async function downloadTgz(url: string, opts: string | DownloadOptions): Promise<string | null> {
+  const options = isString(opts) ? { path: opts } : opts;
+
   const gunzip = createGunzip();
   const extractor = extractTar(options);
   gunzip.pipe(extractor);
@@ -83,10 +80,9 @@ export async function downloadTgz(url: string, options: string | DownloadOptions
   return sum;
 }
 
-export async function downloadZip(url: string, options: string | DownloadOptions): Promise<string | null> {
-  if (isString(options)) {
-    options = { path: options };
-  }
+export async function downloadZip(url: string, opts: string | DownloadOptions): Promise<string | null> {
+  const options = isString(opts) ? { path: opts } : opts;
+
   const extractor = extractZip({ path: options.path as string });
   const sum = await downloadToStream(url, extractor, options.hashType);
   if (!checkHashSum(sum, options)) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,6 @@
 import which from 'which';
 import { GET_CMAKE_VS_GENERATOR } from './util';
+import { BuildMode } from './buildMode'
 
 export type ArrayOrSingle<T> = T | T[];
 
@@ -76,7 +77,7 @@ export type BuildOptionsDefaulted = {
   buildType: string,
   // global cmake options and defines
   globalCMakeOptions?: { name: string, value: string }[];
-  // custom native node abstractions package name if you use a fork instead of official nan
+  // node abstraction API to use (e.g. nan or node-addon-api)
   nodeAPI?: string;
 }
 
@@ -100,23 +101,20 @@ async function whichWrapped(cmd: string): Promise<string | null> {
   }
 }
 
-export async function defaultBuildOptions(configs: BuildOptions, nativeonly: boolean, osonly: boolean): Promise<BuildOptionsDefaulted> {
+export async function defaultBuildOptions(configs: BuildOptions, buildmode: BuildMode): Promise<BuildOptionsDefaulted> {
 
   // Handle missing configs.configurations
   // TODO handle without nativeonly and osonly
-  if (nativeonly && osonly) {
-    console.error(`'osonly' and 'nativeonly' have been specified together. exiting.`);
-    process.exit(1);
-  }
-  if (nativeonly) {
+  if (buildmode.type === 'nativeonly') {
     console.log(
     `--------------------------------------------------
       WARNING: Building only for the current runtime.
       WARNING: DO NOT SHIP THE RESULTING PACKAGE
      --------------------------------------------------`);
+     //Yeah this pretty ugly, but whatever
     configs.configurations = [defaultBuildConfiguration({})];
   }
-  if (osonly) {
+  if (buildmode.type === 'osonly') {
     console.log(
     `--------------------------------------------------
       WARNING: Building only for the current OS.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -9,7 +9,7 @@ export type BuildConfigurationDefaulted = {
   runtime: string,
   runtimeVersion: string,
   toolchainFile: string | null,
-  cmakeOptions?: { name: string, value: string }[];
+  CMakeOptions?: { name: string, value: string }[];
 
   // list of additional definitions to fixup node quirks for some specific versions
   additionalDefines: string[];
@@ -42,8 +42,8 @@ export function defaultBuildConfiguration(config: BuildConfiguration): BuildConf
     config.toolchainFile = null;
   }
 
-  if (config.cmakeOptions === undefined) {
-    config.cmakeOptions = [];
+  if (config.CMakeOptions === undefined) {
+    config.CMakeOptions = [];
   }
 
   config.additionalDefines = [];

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -13,6 +13,7 @@ export type BuildConfigurationDefaulted = {
   runtimeVersion: string,
   toolchainFile: string | null,
   CMakeOptions?: { name: string, value: string }[];
+  addonSubdirectory: string,
 
   // list of additional definitions to fixup node quirks for some specific versions
   additionalDefines: string[];
@@ -53,6 +54,9 @@ export function defaultBuildConfiguration(config: BuildConfiguration): BuildConf
 
   if (config.CMakeOptions === undefined) {
     config.CMakeOptions = [];
+  }
+  if (config.addonSubdirectory === undefined) {
+    config.addonSubdirectory == ''
   }
 
   config.additionalDefines = []; //internal variable, not supposed to be set by the user

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -55,8 +55,13 @@ export function defaultBuildConfiguration(config: BuildConfiguration): BuildConf
   if (config.CMakeOptions === undefined) {
     config.CMakeOptions = [];
   }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((config as any).cmakeOptions !== undefined) {
+    console.warn('cmakeOptions was specified which was disabled in the 0.3.0 release. Please rename it to CMakeOptions');
+  }
+
   if (config.addonSubdirectory === undefined) {
-    config.addonSubdirectory == ''
+    config.addonSubdirectory = ''
   }
 
   config.additionalDefines = []; //internal variable, not supposed to be set by the user
@@ -160,13 +165,13 @@ export async function defaultBuildOptions(configs: BuildOptions, buildmode: Buil
     configs.configurations = [candidateConfig]
     //todo toolchain file?
   }
-  if(buildmode.type == 'named-configs') {
+  if(buildmode.type === 'named-configs') {
     if (configs.configurations === undefined) {
       console.error('No `configurations` entry was found in the package.json');
       process.exit(1);
     }
     //unnamed configs are always filtered out
-    configs.configurations = configs.configurations.filter(j => (!!j.name) ? buildmode.configsToBuild.includes(j.name) : false)
+    configs.configurations = configs.configurations.filter(j => (j.name ? buildmode.configsToBuild.includes(j.name) : false))
     if(configs.configurations.length === 0) {
       console.error(`No configuration left to build!`);
       process.exit(1);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,6 +4,7 @@ import { GET_CMAKE_VS_GENERATOR } from './util';
 export type ArrayOrSingle<T> = T | T[];
 
 export type BuildConfigurationDefaulted = {
+  name: string,
   os: typeof process.platform,
   arch: typeof process.arch,
   runtime: string,
@@ -18,6 +19,9 @@ export type BuildConfigurationDefaulted = {
 export type BuildConfiguration = Partial<BuildConfigurationDefaulted>;
 
 export function defaultBuildConfiguration(config: BuildConfiguration): BuildConfigurationDefaulted {
+  if (config.name === undefined) {
+    config.name = '' //Empty name should be fine (TM)
+  }
   if (config.os === undefined) {
     config.os = process.platform;
     console.warn(`'os' was missing in the 'configurations'. Defaulting to the current operating system ${config.os}`);
@@ -46,7 +50,7 @@ export function defaultBuildConfiguration(config: BuildConfiguration): BuildConf
     config.CMakeOptions = [];
   }
 
-  config.additionalDefines = [];
+  config.additionalDefines = []; //internal variable, not supposed to be set by the user
 
   return config as BuildConfigurationDefaulted;
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -20,22 +20,22 @@ export type BuildConfiguration = Partial<BuildConfigurationDefaulted>;
 export function defaultBuildConfiguration(config: BuildConfiguration): BuildConfigurationDefaulted {
   if (config.os === undefined) {
     config.os = process.platform;
-    console.warn(`'os' was missing in the 'configurations'. Considering the current operating system ${config.os}`);
+    console.warn(`'os' was missing in the 'configurations'. Defaulting to the current operating system ${config.os}`);
   }
 
   if (config.arch === undefined) {
     config.arch = process.arch;
-    console.warn(`'arch' was missing in the 'configurations'. Considering the current architecture ${config.arch}`);
+    console.warn(`'arch' was missing in the 'configurations'. Defaulting to the current architecture ${config.arch}`);
   }
 
   if (config.runtime === undefined) {
     config.runtime = "node";
-    console.warn("`runtime` was missing in the `configurations`. Considering `node`");
+    console.warn("`runtime` was missing in the `configurations`. Defaulting to `node`");
   }
 
   if (config.runtimeVersion === undefined) {
     config.runtimeVersion = process.versions.node;
-    console.warn(`'runtimeVersion' was missing in the 'configurations'. Considering the current runtimeVersion ${config.runtimeVersion}`);
+    console.warn(`'runtimeVersion' was missing in the 'configurations'. Defaulting to the current runtimeVersion ${config.runtimeVersion}`);
   }
 
   if (config.toolchainFile === undefined) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -129,6 +129,10 @@ export async function defaultBuildOptions(configs: BuildOptions, buildmode: Buil
       process.exit(1);
     }
     configs.configurations = configs.configurations.filter(j => j.os === process.platform);
+    if(configs.configurations.length === 0) {
+      console.error(`No configuration left to build!`);
+      process.exit(1);
+    }
     for (const config of configs.configurations) {
       // A native build should be possible without toolchain file.
       config.toolchainFile = null;
@@ -151,6 +155,18 @@ export async function defaultBuildOptions(configs: BuildOptions, buildmode: Buil
     }
     configs.configurations = [candidateConfig]
     //todo toolchain file?
+  }
+  if(buildmode.type == 'named-configs') {
+    if (configs.configurations === undefined) {
+      console.error('No `configurations` entry was found in the package.json');
+      process.exit(1);
+    }
+    //unnamed configs are always filtered out
+    configs.configurations = configs.configurations.filter(j => (!!j.name) ? buildmode.configsToBuild.includes(j.name) : false)
+    if(configs.configurations.length === 0) {
+      console.error(`No configuration left to build!`);
+      process.exit(1);
+    }
   }
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,13 @@ import { ArgumentBuilder } from './argumentBuilder';
 import { RUN } from './util';
 import { ensureDir, remove, copy, pathExists } from 'fs-extra';
 import { applyOverrides } from './override';
+import { determineBuildMode } from './buildMode'
 
 const DEBUG_LOG = Boolean(process.env.CMAKETSDEBUG);
 
 (async (): Promise<void> => {
 
-  const argv = process.argv;
+  const argv = process.argv.slice(2); //Yeah, we don't need advanced command line handling yet
   let packJson: {'cmake-ts': BuildOptions | undefined} & Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   try {
     // TODO getting the path from the CLI
@@ -31,11 +32,10 @@ const DEBUG_LOG = Boolean(process.env.CMAKETSDEBUG);
   }
 
   // check if `nativeonly` or `osonly` option is specified
-  const nativeonly = argv.includes('nativeonly');
-  const osonly = argv.includes('osonly');
+  const buildMode = await determineBuildMode(argv);
 
   // set the missing options to their default value
-  const configs = await defaultBuildOptions(configsGiven, nativeonly, osonly);
+  const configs = await defaultBuildOptions(configsGiven, buildMode);
 
   // Setup directory structure in configs
   // Target directory

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,7 +86,7 @@ const DEBUG_LOG = Boolean(process.env.CMAKETSDEBUG);
     console.log('Runtime:', config.runtime, config.runtimeVersion);
     console.log('Target ABI:', dist.abi);
     console.log('Toolchain File:', config.toolchainFile);
-    console.log('Custom options:', (config.CMakeOptions && config.CMakeOptions.length > 0) ? 'yes' : 'no');
+    console.log('Custom CMake options:', (config.CMakeOptions && config.CMakeOptions.length > 0) ? 'yes' : 'no');
     console.log('Staging area:', stagingDir);
     console.log('Target directory:', targetDir);
     console.log('Build Type', configs.buildType);

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,7 +86,7 @@ const DEBUG_LOG = Boolean(process.env.CMAKETSDEBUG);
     console.log('Runtime:', config.runtime, config.runtimeVersion);
     console.log('Target ABI:', dist.abi);
     console.log('Toolchain File:', config.toolchainFile);
-    console.log('Custom options:', (config.cmakeOptions && config.cmakeOptions.length > 0) ? 'yes' : 'no');
+    console.log('Custom options:', (config.CMakeOptions && config.CMakeOptions.length > 0) ? 'yes' : 'no');
     console.log('Staging area:', stagingDir);
     console.log('Target directory:', targetDir);
     console.log('Build Type', configs.buildType);

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,7 @@ const DEBUG_LOG = Boolean(process.env.CMAKETSDEBUG);
     console.log(`[ DONE, ${appliedOverrides} applied ]`);
 
     console.log('--------------- CONFIG SUMMARY ---------------');
+    console.log('Name: ', config.name ? config.name : "N/A");
     console.log('OS/Arch:', config.os, config.arch);
     console.log('Runtime:', config.runtime, config.runtimeVersion);
     console.log('Target ABI:', dist.abi);

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,8 +73,8 @@ const DEBUG_LOG = Boolean(process.env.CMAKETSDEBUG);
     console.log('[ DONE ]');
 
     process.stdout.write('> Building directories... ');
-    const stagingDir = resolve(join(configs.stagingDirectory, config.os, config.arch, config.runtime, `${dist.abi}`));
-    const targetDir = resolve(join(configs.targetDirectory, config.os, config.arch, config.runtime, `${dist.abi}`));
+    const stagingDir = resolve(join(configs.stagingDirectory, config.os, config.arch, config.runtime, `${dist.abi}`, config.addonSubdirectory));
+    const targetDir = resolve(join(configs.targetDirectory, config.os, config.arch, config.runtime, `${dist.abi}`, config.addonSubdirectory));
     console.log('[ DONE ]');
 
     process.stdout.write('> Applying overrides... ');

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -9,6 +9,7 @@ declare module "memory-stream" {
         private buffer;
         private options;
         constructor(options?: MemoryStreamOptions);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void;
         get(): Buffer;
         toString(): string;

--- a/src/nodeAPIInclude/search.ts
+++ b/src/nodeAPIInclude/search.ts
@@ -27,11 +27,12 @@ async function dirHasFile(dir: string, fileName: string) {
 };
 
 function goUp(dir: string) {
-  const items = dir.split(pathSeparator);
+  let myDir = dir;
+  const items = myDir.split(pathSeparator);
   const scope = items[items.length - 2];
   if (scope && scope.charAt(0) === '@') {
-    dir = joinPath(dir, '..');
+    myDir = joinPath(myDir, '..');
   }
-  dir = joinPath(dir, '..', '..');
-  return normalizePath(dir);
+  myDir = joinPath(myDir, '..', '..');
+  return normalizePath(myDir);
 }


### PR DESCRIPTION
After our real world experiences, I have decided to make numerous adjustments and improvements

- Default to `node-addon-api` instead of `nan`
  - `nan` or in general the native node API may lead to subtle ABI issues and should be avoided (propose to officially discourage it)
  - Using `N-API` or `node-addon-api` solves this issue, because `N-API` or `Node-API` is an ABIs-stable C-API
- Rename undocumented per-configuration option `cmakeOptions` to `CMakeOptions` (to match official name typing and `globalCMakeOptions`) and document it
- Add `name` property to configurations and allow building specific configs via `named-configs`
- Add `dev` property to configurations and allow building a dev config via `dev-os-only`
- Add new build modes
  - `named-configs` only builds configs with matching name (multiple names may be specified)
  - `dev-os-only` builds the first config that has `dev == true` and `os` matches the current OS
- Allow specify a subdirectory for the build per configuration via `addonSubdirectory` if you build addons for multiple architectures in high performance scenarios, you can put the addon inside another subdirectory (i.e. `addonSubdirectory = avx2-generic` => `build/linux/x64/electron/97/addon.node` becomes `build/linux/x64/electron/97/avx2-generic/addon.node`)