### PR TITLE
fix: update Electron mirror to artifacts.electronjs.org

### DIFF
--- a/src/urlRegistry.ts
+++ b/src/urlRegistry.ts
@@ -5,7 +5,7 @@ import os from 'os';
 
 const NODE_MIRROR = process.env.NVM_NODEJS_ORG_MIRROR || "https://nodejs.org/dist";
 const IOJS_MIRROR = process.env.NVM_IOJS_ORG_MIRROR || "https://iojs.org/dist";
-const ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://atom.io/download/atom-shell";
+const ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://artifacts.electronjs.org/headers/dist";
 
 export const HOME_DIRECTORY = process.env[(os.platform() === "win32") ? "USERPROFILE" : "HOME"] as string;
 


### PR DESCRIPTION
The old Electron mirror, `https://atom.io/download/atom-shell`, does not exist anymore and results in obscure

```
> Setting up staging directory... [ DONE ]
---------------- BEGIN CONFIG ----------------
> Distribution File Download... Generic error occured Error: incorrect header check
    at Zlib.zlibOnError [as onerror] (node:zlib:189:17) {
  errno: -3,
  code: 'Z_DATA_ERROR'
}
```

This PR updates the electron mirror to `https://artifacts.electronjs.org/headers/dist` which is the current mirror.