### PR TITLE
Fix: VS CMake Generator Finder can Now Find MSVS 2019+ Automatically

### DIFF
--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -20,7 +20,12 @@ export class ArgumentBuilder {
     const defines = await this.buildDefines();
     baseCommand += ` ${ defines.map(d => `-D${d[0]}="${d[1]}"`).join(" ")}`;
     if (this.options.generatorToUse !== 'native') {
-      baseCommand += ` -G"${this.options.generatorToUse}"`;
+      let generatorString = ` -G"${this.options.generatorToUse}"`;
+      if(generatorString.match(/Visual\s+Studio\s+\d+\s+\d+\s-A/)) {
+        generatorString = generatorString.replace(/\s-A/, '');
+        generatorString += ` -A ${this.config.arch}`;
+      }
+      baseCommand += generatorString;
     }
     console.log(baseCommand)
     return baseCommand;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -212,7 +212,7 @@ export async function defaultBuildOptions(configs: BuildOptions, buildmode: Buil
   let ninja: string | null;
   let make: string | null;
   if (configs.generatorToUse === undefined) {
-    console.log('no generator specified, checking ninja');
+    console.log('no generator specified in package.json, checking ninja');
     ninja = await ninjaP;
     if (!ninja) {
       console.log('ninja not found, checking make');


### PR DESCRIPTION
If a newer version of Visual Studio build tools (>= 2019) is installed then the automatic build tools finder fails because `cmake -G` outputs:
```
Generators
* Visual Studio 17 2022        = Generates Visual Studio 2022 project files.
                                 Use -A option to specify architecture.
  Visual Studio 16 2019        = Generates Visual Studio 2019 project files.
                                 Use -A option to specify architecture.
  Visual Studio 15 2017 [arch] = Generates Visual Studio 2017 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 14 2015 [arch] = Generates Visual Studio 2015 project files.
```

and the function `GET_CMAKE_VS_GENERATOR` doesn't recognise them because it expects the ` [arch]` suffix. 

This fixes:
    - Above issue;
    - Issue where one of the build tools is prefixed by `* ` (I think that means it's the system default or something? Idk;)
    - For the build tools that don't end with ` [arch]`, it appends `-A arch` to the generator string in the argumentBuilder (kinda janky).