### PR TITLE
feat: create a manifest for the built configurations + include glibc/abi

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "bin": "build/main.js",
   "scripts": {
-    "clean": "shx rm -rf build",
+    "clean": "shx rm -rf build ./test/.tmp",
     "lint.eslint": "eslint . --cache --cache-location ./.cache/.eslintcache \"./**/*.{js,ts,mjs,mts,cjs,cts,json,yaml,yml}\" --fix",
     "lint.biome": "biome check --write --unsafe .",
     "lint": "turbo run lint.eslint lint.biome",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/tar": "^6.1.13",
     "@types/url-join": "~4.0.3",
     "@types/which": "~3.0.4",
+    "@types/escape-quotes": "^1.0.0",
     "@upleveled/babel-plugin-remove-node-prefix": "^1.0.5",
     "turbo": "^2.4.4",
     "cross-env": "^7.0.3",
@@ -113,9 +114,10 @@
     "tar": "^6",
     "url-join": "^4.0.1",
     "which": "^2",
-    "node-downloader-helper": "^2.1.7"
+    "node-downloader-helper": "^2.1.7",
+    "escape-quotes": "^1.0.2"
   },
-  "packageManager": "pnpm@10.6.5",
+  "packageManager": "pnpm@10.7.0",
   "$schema": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/package.json",
   "pnpm": {
     "onlyBuiltDependencies": ["core-js", "esbuild"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/babel__core':
         specifier: ~7.20.5
         version: 7.20.5
+      '@types/escape-quotes':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/fs-extra':
         specifier: ~11.0.4
         version: 11.0.4
@@ -50,6 +53,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      escape-quotes:
+        specifier: ^1.0.2
+        version: 1.0.2
       eslint:
         specifier: '8'
         version: 8.57.1
@@ -634,6 +640,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/escape-quotes@1.0.0':
+    resolution: {integrity: sha512-W7MUb/9brjZoqT/lWoYnwwudLct8N7GEXPeeVTfF17rkEPPYAPsn2pn/AG/VNaFCuU7ws3Qc6tcKTAIG84k0tA==}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
@@ -1402,6 +1411,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-quotes@1.0.2:
+    resolution: {integrity: sha512-JpLFzklNReeakCpyj59s78P5F72q0ZUpDnp2BuIk9TtTjj2HMsgiWBChw17BlZT8dRhMtmSb1jE2+pTP1iFYyw==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -3842,6 +3854,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/escape-quotes@1.0.0': {}
+
   '@types/estree@1.0.7': {}
 
   '@types/fs-extra@11.0.4':
@@ -4788,8 +4802,11 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@1.0.5:
-    optional: true
+  escape-quotes@1.0.2:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
+  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -17,6 +17,12 @@ export type BuildConfigurationDefaulted = {
 
   // list of additional definitions to fixup node quirks for some specific versions
   additionalDefines: string[]
+
+  /** The ABI number that is used by the runtime. */
+  abi?: number
+
+  /** The libc that is used by the runtime. */
+  libc?: string
 }
 
 export type BuildConfiguration = Partial<BuildConfigurationDefaulted>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@
 
 /* eslint-disable node/shebang */
 
-import { join, resolve } from "path"
-import { copy, ensureDir, pathExists, readJson, remove } from "fs-extra"
+import { join, relative, resolve } from "path"
+import { copy, ensureDir, pathExists, readJson, remove, writeFile, readFile } from "fs-extra"
 import { ArgumentBuilder } from "./argumentBuilder.js"
 import { determineBuildMode } from "./buildMode.js"
 import { type BuildOptions, defaultBuildConfiguration, defaultBuildOptions } from "./lib.js"
@@ -127,18 +127,27 @@ async function main(): Promise<void> {
     // Copy back the previously built binary
     process.stdout.write(`> Copying ${configs.projectName}.node to target directory... `)
     await ensureDir(targetDir)
-    if (configs.generatorToUse.includes("Visual Studio")) {
-      if (DEBUG_LOG !== undefined) {
-        console.log("Applying copy fix for MSVC projects")
-      }
-      await copy(
-        join(stagingDir, configs.buildType, `${configs.projectName}.node`),
-        join(targetDir, `${configs.projectName}.node`),
-      )
-    } else {
-      await copy(join(stagingDir, `${configs.projectName}.node`), join(targetDir, `${configs.projectName}.node`))
-    }
+
+    const addonPath = join(targetDir, `${configs.projectName}.node`)
+    const sourceAddonPath = configs.generatorToUse.includes("Visual Studio")
+      ? join(stagingDir, configs.buildType, `${configs.projectName}.node`)
+      : join(stagingDir, `${configs.projectName}.node`)
+    await copy(sourceAddonPath, addonPath)
+
     console.log("[ DONE ]")
+
+    console.log("Adding the built config to the manifest file...")
+
+    // read the manifest if it exists
+    const manifestPath = join(configs.targetDirectory, "manifest.json")
+    let manifest: Record<string, string> = {}
+    if (await pathExists(manifestPath)) {
+      const manifestContent = await readFile(manifestPath, "utf-8")
+      manifest = JSON.parse(manifestContent)
+    }
+    // add the new entry to the manifest
+    manifest[JSON.stringify(config)] = relative(configs.targetDirectory, addonPath)
+    await writeFile(manifestPath, JSON.stringify(manifest, null, 2))
 
     console.log("----------------- END CONFIG -----------------")
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 /* eslint-disable node/shebang */
 
 import { join, relative, resolve } from "path"
-import { copy, ensureDir, pathExists, readJson, remove, writeFile, readFile } from "fs-extra"
+import { copy, ensureDir, pathExists, readFile, readJson, remove, writeFile } from "fs-extra"
 import { ArgumentBuilder } from "./argumentBuilder.js"
 import { determineBuildMode } from "./buildMode.js"
 import { type BuildOptions, defaultBuildConfiguration, defaultBuildOptions } from "./lib.js"

--- a/test/zeromq.test.ts
+++ b/test/zeromq.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url"
 import { isCI } from "ci-info"
 import { existsSync, readJson, remove } from "fs-extra"
 import { beforeAll, beforeEach, expect, suite, test } from "vitest"
+import type { BuildConfigurationDefaulted } from "../src/lib.js"
 import { HOME_DIRECTORY } from "../src/urlRegistry.js"
 
 const dirname = typeof __dirname === "string" ? __dirname : path.dirname(fileURLToPath(import.meta.url))
@@ -53,19 +54,25 @@ suite("zeromq", { timeout: 300_000 }, (tests) => {
       expect(existsSync(manifestPath), `Manifest file ${manifestPath} does not exist`).toBe(true)
       const manifest = (await readJson(manifestPath)) as Record<string, string>
 
+      const configKey = JSON.parse(Object.keys(manifest)[0]) as BuildConfigurationDefaulted
+
+      const expectedConfig: BuildConfigurationDefaulted = {
+        name: "",
+        dev: false,
+        os: process.platform,
+        arch: process.arch,
+        runtime: "node",
+        runtimeVersion: process.versions.node,
+        toolchainFile: null,
+        CMakeOptions: [],
+        addonSubdirectory: "",
+        additionalDefines: [],
+        abi: configKey.abi,
+        libc: configKey.libc,
+      }
+
       expect(manifest).toEqual({
-        [JSON.stringify({
-          name: "",
-          dev: false,
-          os: process.platform,
-          arch: process.arch,
-          runtime: "node",
-          runtimeVersion: process.versions.node,
-          toolchainFile: null,
-          CMakeOptions: [],
-          addonSubdirectory: "",
-          additionalDefines: [],
-        })]: addonPath,
+        [JSON.stringify(expectedConfig)]: addonPath,
       })
 
       // check if the addon.node file exists

--- a/test/zeromq.test.ts
+++ b/test/zeromq.test.ts
@@ -2,10 +2,10 @@ import { execFileSync } from "child_process"
 import path, { join } from "path"
 import { fileURLToPath } from "url"
 import { isCI } from "ci-info"
-import glob from "fast-glob"
-import { existsSync, remove } from "fs-extra"
+import { existsSync, readJson, remove } from "fs-extra"
 import { beforeAll, beforeEach, expect, suite, test } from "vitest"
 import { HOME_DIRECTORY } from "../src/urlRegistry.js"
+
 const dirname = typeof __dirname === "string" ? __dirname : path.dirname(fileURLToPath(import.meta.url))
 const root = path.dirname(dirname)
 
@@ -46,14 +46,31 @@ suite("zeromq", { timeout: 300_000 }, (tests) => {
         cwd: zeromqPath,
       })
 
-      const addons = await glob(`build/${process.platform}/${process.arch}/node/*/addon.node`, {
-        cwd: zeromqPath,
-        absolute: true,
-        onlyFiles: true,
-        braceExpansion: false,
+      const addonPath = `${process.platform}/${process.arch}/node/131/addon.node`
+
+      // check manifest file
+      const manifestPath = join(zeromqPath, "build/manifest.json")
+      expect(existsSync(manifestPath), `Manifest file ${manifestPath} does not exist`).toBe(true)
+      const manifest = (await readJson(manifestPath)) as Record<string, string>
+
+      expect(manifest).toEqual({
+        [JSON.stringify({
+          name: "",
+          dev: false,
+          os: process.platform,
+          arch: process.arch,
+          runtime: "node",
+          runtimeVersion: process.versions.node,
+          toolchainFile: null,
+          CMakeOptions: [],
+          addonSubdirectory: "",
+          additionalDefines: [],
+        })]: addonPath,
       })
 
-      expect(addons.length).toBe(1)
+      // check if the addon.node file exists
+      const addonNodePath = join(zeromqPath, "build", addonPath)
+      expect(existsSync(addonNodePath), `Addon node file ${addonNodePath} does not exist`).toBe(true)
     })
   }
 })


### PR DESCRIPTION
This adds a `manifest.json` for the built binaries under built that allows the package to load the correct addon path during runtime. This PR also adds the glibc/abi as information in the key


The manifest includes the build config serialized as the key to the path of the addon:
```json
{
  "{\"name\":\"\",\"dev\":false,\"os\":\"darwin\",\"arch\":\"arm64\",\"runtime\":\"node\",\"runtimeVersion\":\"23.4.0\",\"toolchainFile\":null,\"CMakeOptions\":[],\"addonSubdirectory\":\"\",\"additionalDefines\":[],\"abi\":131,\"libc\":\"libc\"}": "darwin/arm64/node/131/addon.node"
}
```

Allows fixing https://github.com/zeromq/zeromq.js/issues/715 by loading the correct binary for Musl/Glibc